### PR TITLE
Fix: Support strict dependency injection mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ var AngularMiddleEllipses = angular.module(MODULE_NAME, []);
 // Exposed for testability purposes
 AngularMiddleEllipses.constant('MIDDLE_ELLIPSES_CHARACTER', '…');
 
-AngularMiddleEllipses.filter('middleEllipses', function(MIDDLE_ELLIPSES_CHARACTER) {
+AngularMiddleEllipses.filter('middleEllipses', ['MIDDLE_ELLIPSES_CHARACTER', function(MIDDLE_ELLIPSES_CHARACTER) {
 
   /**
    * @summary Middle ellipses filter
@@ -82,6 +82,6 @@ AngularMiddleEllipses.filter('middleEllipses', function(MIDDLE_ELLIPSES_CHARACTE
     return finalLeftPart + MIDDLE_ELLIPSES_CHARACTER + finalRightPart;
   };
 
-});
+}]);
 
 module.exports = MODULE_NAME;


### PR DESCRIPTION
It was not possible to use this filter inside of an application that uses the `ng-strict-di` directive since the injection of `MIDDLE_ELLIPSIS_CHARACTER` was not specified explicitly, and would throw an error: `middleEllipsis is not using explicit annotation and cannot be invoked in strict mode`